### PR TITLE
Specify ruby version and bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+ruby '2.4.4'
+
 source "http://rubygems.org"
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,5 +195,8 @@ DEPENDENCIES
   simplecov (~> 0.15.1)
   webmock (~> 3.3, >= 3.3.0)
 
+RUBY VERSION
+   ruby 2.4.4p296
+
 BUNDLED WITH
    1.16.1

--- a/lib/i18n_country_translations/version.rb
+++ b/lib/i18n_country_translations/version.rb
@@ -1,3 +1,3 @@
 module I18nCountryTranslations
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end


### PR DESCRIPTION
## What?

Attempt to fix the deployment pipeline by specifying ruby version and bumping the gem.

```
The following gems are missing
 * iso (0.2.2)
 * i18n-spec (0.6.0)
 * webmock (3.3.0)
Install missing gems with `bundle install`
The latest bundler is 1.16.2, but you are currently running 1.15.4.
To update, run `gem install bundler`
Warning: the running version of Bundler (1.15.4) is older than the version that created the lockfile (1.16.1). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.
```