### PR TITLE
Rename Saint Martin to Sint Marteen

### DIFF
--- a/rails/locale/iso_639-1/en.yml
+++ b/rails/locale/iso_639-1/en.yml
@@ -219,7 +219,7 @@ en:
     SS: South Sudan
     ST: São Tomé & Príncipe
     SV: El Salvador
-    SX: Saint Martin
+    SX: Sint Marteen
     SY: Syria
     SZ: Swaziland
     TA: Tristan da Cunha


### PR DESCRIPTION
This PR renames the country name of SX to `Sint Marteen`.

**Why is this safe?**
This value is only surface when calling `I18n.t('SX', scope: :countries)` and is called from https://github.com/Shopify/shopify/blob/master/components/platform/app/controllers/concerns/available_countries_concern.rb#L40 in checkout which is then just used as a label https://github.com/Shopify/shopify/blob/master/components/platform/app/controllers/concerns/available_countries_concern.rb#L22

See https://github.com/Shopify/shopify/issues/138866