### PR TITLE
Add NO as an alias to NB

### DIFF
--- a/lib/i18n_country_translations/version.rb
+++ b/lib/i18n_country_translations/version.rb
@@ -1,3 +1,3 @@
 module I18nCountryTranslations
-  VERSION = "1.3.5"
+  VERSION = "1.3.6"
 end

--- a/rails/locale/iso_639-1/no.yml
+++ b/rails/locale/iso_639-1/no.yml
@@ -1,0 +1,263 @@
+# alias to nb
+---
+'no':
+  countries:
+    AC: Ascension
+    AD: Andorra
+    AE: De forente arabiske emirater
+    AF: Afghanistan
+    AG: Antigua og Barbuda
+    AI: Anguilla
+    AL: Albania
+    AM: Armenia
+    AN: De nederlandske antiller
+    AO: Angola
+    AQ: Antarktis
+    AR: Argentina
+    AS: Amerikansk Samoa
+    AT: Østerrike
+    AU: Australia
+    AW: Aruba
+    AX: Åland
+    AZ: Aserbajdsjan
+    BA: Bosnia-Hercegovina
+    BB: Barbados
+    BD: Bangladesh
+    BE: Belgia
+    BF: Burkina Faso
+    BG: Bulgaria
+    BH: Bahrain
+    BI: Burundi
+    BJ: Benin
+    BL: Saint-Barthélemy
+    BM: Bermuda
+    BN: Brunei
+    BO: Bolivia
+    BQ: Karibisk Nederland
+    BR: Brasil
+    BS: Bahamas
+    BT: Bhutan
+    BV: Bouvetøya
+    BW: Botswana
+    BY: Hviterussland
+    BZ: Belize
+    CA: Canada
+    CC: Kokosøyene
+    CD: Kongo-Kinshasa
+    CF: Den sentralafrikanske republikk
+    CG: Kongo-Brazzaville
+    CH: Sveits
+    CI: Elfenbenskysten
+    CK: Cookøyene
+    CL: Chile
+    CM: Kamerun
+    CN: Kina
+    CO: Colombia
+    CP: Clippertonøya
+    CR: Costa Rica
+    CU: Cuba
+    CV: Kapp Verde
+    CW: Curaçao
+    CX: Christmasøya
+    CY: Kypros
+    CZ: Tsjekkia
+    DE: Tyskland
+    DG: Diego Garcia
+    DJ: Djibouti
+    DK: Danmark
+    DM: Dominica
+    DO: Den dominikanske republikk
+    DZ: Algerie
+    EA: Ceuta og Melilla
+    EC: Ecuador
+    EE: Estland
+    EG: Egypt
+    EH: Vest-Sahara
+    ER: Eritrea
+    ES: Spania
+    ET: Etiopia
+    EU: EU
+    FI: Finland
+    FJ: Fiji
+    FK: Falklandsøyene
+    FM: Mikronesiaføderasjonen
+    FO: Færøyene
+    FR: Frankrike
+    GA: Gabon
+    GB: Storbritannia
+    GD: Grenada
+    GE: Georgia
+    GF: Fransk Guyana
+    GG: Guernsey
+    GH: Ghana
+    GI: Gibraltar
+    GL: Grønland
+    GM: Gambia
+    GN: Guinea
+    GP: Guadeloupe
+    GQ: Ekvatorial-Guinea
+    GR: Hellas
+    GS: Sør-Georgia og Sør-Sandwichøyene
+    GT: Guatemala
+    GU: Guam
+    GW: Guinea-Bissau
+    GY: Guyana
+    HK: Hongkong S.A.R. Kina
+    HM: Heard- og McDonaldøyene
+    HN: Honduras
+    HR: Kroatia
+    HT: Haiti
+    HU: Ungarn
+    IC: Kanariøyene
+    ID: Indonesia
+    IE: Irland
+    IL: Israel
+    IM: Man
+    IN: India
+    IO: Britiske territorier i Indiahavet
+    IQ: Irak
+    IR: Iran
+    IS: Island
+    IT: Italia
+    JE: Jersey
+    JM: Jamaica
+    JO: Jordan
+    JP: Japan
+    KE: Kenya
+    KG: Kirgisistan
+    KH: Kambodsja
+    KI: Kiribati
+    KM: Komorene
+    KN: St. Kitts og Nevis
+    KP: Nord-Korea
+    KR: Sør-Korea
+    KW: Kuwait
+    KY: Caymanøyene
+    KZ: Kasakhstan
+    LA: Laos
+    LB: Libanon
+    LC: St. Lucia
+    LI: Liechtenstein
+    LK: Sri Lanka
+    LR: Liberia
+    LS: Lesotho
+    LT: Litauen
+    LU: Luxemburg
+    LV: Latvia
+    LY: Libya
+    MA: Marokko
+    MC: Monaco
+    MD: Moldova
+    ME: Montenegro
+    MF: Saint-Martin
+    MG: Madagaskar
+    MH: Marshalløyene
+    MK: Makedonia
+    ML: Mali
+    MM: Myanmar (Burma)
+    MN: Mongolia
+    MO: Macao S.A.R. Kina
+    MP: Nord-Marianene
+    MQ: Martinique
+    MR: Mauritania
+    MS: Montserrat
+    MT: Malta
+    MU: Mauritius
+    MV: Maldivene
+    MW: Malawi
+    MX: Mexico
+    MY: Malaysia
+    MZ: Mosambik
+    NA: Namibia
+    NC: Ny-Caledonia
+    NE: Niger
+    NF: Norfolkøya
+    NG: Nigeria
+    NI: Nicaragua
+    NL: Nederland
+    'NO': Norge
+    NP: Nepal
+    NR: Nauru
+    NU: Niue
+    NZ: New Zealand
+    OM: Oman
+    PA: Panama
+    PE: Peru
+    PF: Fransk Polynesia
+    PG: Papua Ny-Guinea
+    PH: Filippinene
+    PK: Pakistan
+    PL: Polen
+    PM: St. Pierre og Miquelon
+    PN: Pitcairn
+    PR: Puerto Rico
+    PS: Det palestinske området
+    PT: Portugal
+    PW: Palau
+    PY: Paraguay
+    QA: Qatar
+    QO: ytre Oseania
+    RE: Réunion
+    RO: Romania
+    RS: Serbia
+    RU: Russland
+    RW: Rwanda
+    SA: Saudi-Arabia
+    SB: Salomonøyene
+    SC: Seychellene
+    SD: Sudan
+    SE: Sverige
+    SG: Singapore
+    SH: St. Helena
+    SI: Slovenia
+    SJ: Svalbard og Jan Mayen
+    SK: Slovakia
+    SL: Sierra Leone
+    SM: San Marino
+    SN: Senegal
+    SO: Somalia
+    SR: Surinam
+    SS: Sør-Sudan
+    ST: São Tomé og Príncipe
+    SV: El Salvador
+    SX: Sint Maarten
+    SY: Syria
+    SZ: Swaziland
+    TA: Tristan da Cunha
+    TC: Turks- og Caicosøyene
+    TD: Tsjad
+    TF: De franske sørterritorier
+    TG: Togo
+    TH: Thailand
+    TJ: Tadsjikistan
+    TK: Tokelau
+    TL: Øst-Timor
+    TM: Turkmenistan
+    TN: Tunisia
+    TO: Tonga
+    TR: Tyrkia
+    TT: Trinidad og Tobago
+    TV: Tuvalu
+    TW: Taiwan
+    TZ: Tanzania
+    UA: Ukraina
+    UG: Uganda
+    UM: USAs ytre øyer
+    US: USA
+    UY: Uruguay
+    UZ: Usbekistan
+    VA: Vatikanstaten
+    VC: St. Vincent og Grenadinene
+    VE: Venezuela
+    VG: De britiske jomfruøyene
+    VI: De amerikanske jomfruøyene
+    VN: Vietnam
+    VU: Vanuatu
+    WF: Wallis og Futuna
+    WS: Samoa
+    XK: Kosovo
+    YE: Jemen
+    YT: Mayotte
+    ZA: Sør-Afrika
+    ZM: Zambia
+    ZW: Zimbabwe

--- a/spec/unit/translations_spec.rb
+++ b/spec/unit/translations_spec.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
-describe "single call" do
+describe "countries" do
   it "translates correctly" do
     expect(I18n.t(:ES, :scope => :countries)).to eql "Spain"
+  end
+
+  it "NO (Norwegian) mimics NB (Norwegian Bokmål)" do
+    expect(I18n.t(:countries, locale: :nb)).to eql I18n.t(:countries, locale: :no)
   end
 end
 


### PR DESCRIPTION
Partially fixes and ref: https://github.com/Shopify/shopify/issues/165940

Technically, Norwegian (no) isn't a valid language, as it's a metalanguage composed of both nb and nn, two norwegian dialects. However, it is a valid option through all our offerings, and is considered valid based on our own [locale list](https://github.com/Shopify/shopify/blob/master/db/data/locales.yml#L132). For this reason, as most people do, I'm making it available as a copy of nb, as most systems do in this situation.

<img width="559" alt="screen shot 2018-08-17 at 3 09 59 pm" src="https://user-images.githubusercontent.com/596120/44268558-1c337900-a232-11e8-9db5-e7e46d481f5a.png">

On a side note, I'm 95% convinced `no` hasn't made it to the list of official languages simply because of the way YML parses `no` as a special keyword...

Before;

<img width="362" alt="screen shot 2018-08-17 at 4 07 48 pm" src="https://user-images.githubusercontent.com/596120/44271606-e34bd200-a23a-11e8-9e11-c11feae4acde.png">

After;

<img width="390" alt="screen shot 2018-08-17 at 4 30 25 pm" src="https://user-images.githubusercontent.com/596120/44271617-e6df5900-a23a-11e8-8124-e25ec93881d0.png">
