### PR TITLE
Relax gemspec dependencies

### DIFF
--- a/i18n-country-translations.gemspec
+++ b/i18n-country-translations.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.platform     = Gem::Platform::RUBY
 
-  s.add_dependency('i18n', '~> 1.0.1')
+  s.add_dependency('i18n', '>= 1.0.1', '< 2')
   s.add_runtime_dependency "railties", '>= 4.0'
   s.add_development_dependency "rails", "~> 5.2.0"
   s.add_development_dependency 'rspec-rails', '~> 3.7', '>= 3.7.2'

--- a/lib/i18n_country_translations/version.rb
+++ b/lib/i18n_country_translations/version.rb
@@ -1,3 +1,3 @@
 module I18nCountryTranslations
-  VERSION = "1.3.6"
+  VERSION = "1.3.7"
 end


### PR DESCRIPTION
Similar to what was done upstream: https://github.com/onomojo/i18n-country-translations/commit/12a902f6c8e05d54518c9e87ab63cfab20dfe9d5

We need this relaxation in core to use `i18n=1.6.0` that contains the new `I18n.locale = false` feature.

