### PR TITLE
Fix Gemlfile.lock for v1.3.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    i18n-country-translations (1.3.7)
+    i18n-country-translations (1.3.8)
       i18n (>= 1.0.1, < 2)
       railties (>= 4.0)
 


### PR DESCRIPTION
I broke the deploy last commit by forgetting to update the Gemfile.lock >.<. This fixes it by:
1. Committing `Gemfile.lock` after a `bundle update i18n-country-translations  --conservative`
2. Remove previous `v1.3.8` tag and tag this commit with `v1.3.8`